### PR TITLE
Fix version extraction

### DIFF
--- a/src/build/utils.sh
+++ b/src/build/utils.sh
@@ -100,7 +100,7 @@ get_apk() {
 	if [[ -z $version ]]; then
  		local list_ver
   		list_ver=$(req "https://www.apkmirror.com/uploads/?appcategory=$2" -)
-    		version=$(sed -n 's;.*<a class="fontBlack" href="/apk/'"$3"'-.*-release/">[^0-9]*\(.*\)</a> </h5>.*;\1;p' <<<"$list_ver" | grep -v 'beta\|alpha' | head -n 1)
+    		version=$(sed -n 's;.*<a class="fontBlack" href="/apk/'"$3"'-.*-release/">[^0-9]*\(.*\)</a> </h5>.*;\1;p' <<<"$list_ver" | grep -v 'beta\|alpha' | sed 's/\([0-9\.]*\).*/\1/' | head -n 1)
 	fi
 	echo "Downloading $2 $4 version: $version $5 $6"
 	local base_apk="$1.apk"

--- a/src/build/utils.sh
+++ b/src/build/utils.sh
@@ -98,14 +98,9 @@ get_apk() {
 	fi
 	export version="$version"
 	if [[ -z $version ]]; then
- 		local list_vers v versions=()
-  		list_vers=$(req "https://www.apkmirror.com/uploads/?appcategory=$2" -)
-		version=$(sed -n 's;.*Version:</span><span class="infoSlide-value">\(.*\) </span>.*;\1;p' <<<"$list_vers")
-		version=$(grep -iv "\(beta\|alpha\)" <<<"$version")
-		for v in $version; do
-			grep -iq "${v} \(beta\|alpha\)" <<<"$list_vers" || versions+=("$v")
-		done
-		version=$(head -1 <<<"$versions")
+ 		local list_ver
+  		list_ver=$(req "https://www.apkmirror.com/uploads/?appcategory=$2" -)
+    		version=$(sed -n 's;.*<a class="fontBlack" href="/apk/'"$3"'-.*-release/">[^0-9]*\(.*\)</a> </h5>.*;\1;p' <<<"$list_ver" | grep -v 'beta\|alpha' | head -n 1)
 	fi
 	echo "Downloading $2 $4 version: $version $5 $6"
 	local base_apk="$1.apk"

--- a/src/build/utils.sh
+++ b/src/build/utils.sh
@@ -100,7 +100,7 @@ get_apk() {
 	if [[ -z $version ]]; then
  		local list_ver
   		list_ver=$(req "https://www.apkmirror.com/uploads/?appcategory=$2" -)
-    		version=$(sed -n 's;.*<a class="fontBlack" href="/apk/'"$3"'-.*-release/">[^0-9]*\(.*\)</a> </h5>.*;\1;p' <<<"$list_ver" | grep -v 'beta\|alpha' | sed 's/\([0-9\.]*\).*/\1/' | head -n 1)
+    		version=$(sed -n 's;.*<a class="fontBlack" href="/apk/'"$3"'-.*-release/">[^0-9]*\(.*\)</a> </h5>.*;\1;p' <<<"$list_ver" | grep -E 'rc|^[0-9\.]*$' | sed 's/\([0-9\.]*\(-rc\)*\).*/\1/' | head -n 1)
 	fi
 	echo "Downloading $2 $4 version: $version $5 $6"
 	local base_apk="$1.apk"


### PR DESCRIPTION
Amend `get_apk` function: get the latest version excluding `alpha/beta`.