### PR TITLE
fix: TikTok crash fixed in next stable release.

### DIFF
--- a/src/build/Revanced.sh
+++ b/src/build/Revanced.sh
@@ -57,8 +57,7 @@ revanced_dl(){
 	patch "gg-photos-armeabi-v7a" "revanced"
 }
 4() {
-	dl_gh "revanced-patches" "revanced" "v5.7.2" #Force version this because crash on startup lastest rv patches
-	dl_gh "revanced-cli" "revanced" "latest"
+	revanced_dl
 	# Patch Tiktok:
 	get_patches_key "tiktok"
 	url="https://tiktok.en.uptodown.com/android/download/1032081983" #Use uptodown because apkmirror ban tiktok in US lead github action can't download apk file


### PR DESCRIPTION
Like [69d128b](https://github.com/FiorenMas/Revanced-And-Revanced-Extended-Non-Root/commit/69d128b67b43ec0203142ca6e7751bc8af2c7b09) Whenever the next stable release for Revanced is available, the fix will be incorporated meaning this can be changed back to latest version.