### PR TITLE
fix: req facebook's arm64-v8a apks

### DIFF
--- a/src/build/Revanced-Beta.sh
+++ b/src/build/Revanced-Beta.sh
@@ -42,7 +42,7 @@ revanced_dl(){
 	# Patch Facebook:
 	# Arm64-v8a
 	get_patches_key "facebook"
-	url="https://d.apkpure.com/b/APK/com.facebook.katana?versionCode=457020009"
+	url="https://d.apkpure.com/b/APK/com.facebook.katana?versionCode=457020014"
 	req "$url" "facebook-arm64-v8a-beta.apk"
 	patch "facebook-arm64-v8a-beta" "revanced"
 }

--- a/src/build/Revanced.sh
+++ b/src/build/Revanced.sh
@@ -41,7 +41,7 @@ revanced_dl(){
 	# Patch Facebook:
 	# Arm64-v8a
 	get_patches_key "facebook"
-	url="https://d.apkpure.com/b/APK/com.facebook.katana?versionCode=457020009"
+	url="https://d.apkpure.com/b/APK/com.facebook.katana?versionCode=457020014"
 	req "$url" "facebook-arm64-v8a.apk"
 	patch "facebook-arm64-v8a" "revanced"
 }


### PR DESCRIPTION
457020009 points to armeabi-v7a, 457020014 points to the correct arm64-v8a one